### PR TITLE
Litex rebase

### DIFF
--- a/ports/litex/Makefile
+++ b/ports/litex/Makefile
@@ -1,4 +1,5 @@
 # This file is Copyright (c) 2017-2021 Fupy/LiteX-MicroPython Developers
+# Copyright (c) 2021-2022 Victor Suarez Rovere <suarezvictor@gmail.com>
 # License: BSD-2-Clause
 
 # Check LiteX's BUILD_DIRECTORY definition.
@@ -34,8 +35,9 @@ CROSS_COMPILE ?= $(TRIPLE)-
 ASFLAGS += -I$(BUILD_DIRECTORY)/software/include # For crt0.S.
 
 CFLAGS += $(CPUFLAGS)
-CFLAGS += $(INC) -Wall -Werror -std=gnu11 -ggdb $(COPT)
-CFLAGS += -Og -Wdouble-promotion -Wall -Werror
+#CFLAGS += $(INC) -Wall -Werror -std=gnu11 -ggdb $(COPT)
+CFLAGS += $(INC) -Wall -Wno-error -std=gnu11 -ggdb $(COPT)
+CFLAGS += -Og -Wdouble-promotion
 
 # Set Include directories.
 INC += -I.
@@ -59,6 +61,7 @@ SRC_C = \
 	$(SOC_DIRECTORY)/software/libbase/uart.c \
 	isr.c \
 	modmachine.c \
+	modutime.c \
 	modlitex.c \
 	litex_pin.c \
 	litex_led.c \
@@ -67,6 +70,7 @@ SRC_C = \
 	lib/utils/stdout_helpers.c \
 	lib/utils/interrupt_char.c \
 	lib/utils/pyexec.c \
+        lib/timeutils/timeutils.c \
 	lib/mp-readline/readline.c
 
 DRIVERS_SRC_C = $(addprefix drivers/,\

--- a/ports/litex/examples/MACHINE_demo.py
+++ b/ports/litex/examples/MACHINE_demo.py
@@ -1,0 +1,7 @@
+import gc
+import umachine
+print("Machine identifier:", umachine.identifier())
+print("Clock frequency:", umachine.freq()/1.e6, "MHz")
+gc.collect()
+print("Free memory:", gc.mem_free()/1024, "KiB")
+

--- a/ports/litex/examples/TIME_demo.py
+++ b/ports/litex/examples/TIME_demo.py
@@ -1,0 +1,39 @@
+# TIME FUNCTIONS demo
+#
+# if in REPL use "Paste Mode" (Ctrl-E then Ctrl-D)
+# to get the required precison
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+
+import umachine
+from utime import *
+
+t0 = ticks_ms()
+sleep_ms(1000)
+t = ticks_diff(ticks_ms(), t0)
+assert(t < 1001 and t > 999)
+print("ms precision", t/1000)
+
+t0 = ticks_us()
+sleep_us(1000000)
+t = ticks_diff(ticks_us(), t0)
+assert(t < 1001000 and t > 999000)
+print("us precision", t/1000000)
+
+t0 = time_ns()
+sleep_ms(1000)
+t1 = time_ns()
+if t1 < t0: t1 += 2**32 #ticks_diff doesn't work well
+t = t1 - t0
+assert(t < 1001000000 and t > 999000000)
+print("ns precision", t/1000000000)
+
+f = umachine.freq()
+t0 = ticks_cpu()
+sleep_us(1000000)
+t = ticks_diff(ticks_cpu(), t0)
+assert(t > 0.999*f and t < 1.001*f)
+print("ticks_cpu precision", t/f)
+
+

--- a/ports/litex/examples/main.py
+++ b/ports/litex/examples/main.py
@@ -1,0 +1,8 @@
+#raw REPL demo
+#
+#can be executed as follows:
+#$ pyboard.py -d /dev/ttyUSB1 -b 1000000 examples/main.py
+#Alternatively, can be copied to the board flash storage
+#to be run at boot
+#
+print("Hello from main.py!")

--- a/ports/litex/linker.ld
+++ b/ports/litex/linker.ld
@@ -53,4 +53,5 @@ SECTIONS
 PROVIDE(_fstack = ORIGIN(sram) + LENGTH(sram) - 4);
 
 PROVIDE(_fdata_rom = LOADADDR(.data));
-PROVIDE(_edata_rom = LOADADDR(.data) + SIZEOF(.data));
+PROVIDE(_edata_rom = LOADADDR(.data) + SIZEOF(.data)); /*start of heap*/
+PROVIDE(_emain_ram = ORIGIN(main_ram) + LENGTH(main_ram)); /*TODO: consider shared video RAM*/

--- a/ports/litex/machine_pwm.c
+++ b/ports/litex/machine_pwm.c
@@ -36,6 +36,7 @@
 #include "modmachine.h"
 #include "mphalport.h"
 
+#ifdef CSR_LEDS_PWM_ENABLE_ADDR //TODO: change led control to general PWM array when implemented
 // Forward dec'l
 extern const mp_obj_type_t machine_pwm_type;
 
@@ -45,6 +46,7 @@ typedef struct _pwm_obj_t {
     uint8_t active;
     uint8_t channel;
 } pwm_obj_t;
+#endif
 
 #ifdef ESP32 //see notes in machine_hw_spi.c about reusing code from ESP32 port
 // Which channel has which GPIO pin assigned?

--- a/ports/litex/main.c
+++ b/ports/litex/main.c
@@ -69,15 +69,29 @@ static char *stack_top;
 extern char _edata_rom, _emain_ram;
 #endif
 
+void NORETURN hard_reset() { ctrl_reset_write(1); for(;;); } //TODO: move to SDK
+int upython_main(int argc, char **argv);
 
 int main(int argc, char **argv) {
     int stack_dummy;
     stack_top = (char*)&stack_dummy;
+    //safe way to determine stack top: no other variables in this function //TODO: use alloca()
 
     irq_setmask(0);
     irq_setie(1);
     uart_init();
 
+    while(upython_main(argc, argv) == 0)
+        /*soft_reset()*/;
+
+    irq_setie(0);
+    irq_setmask(~0);
+
+    hard_reset();
+}
+
+int upython_main(int argc, char **argv)
+{
 #if MICROPY_ENABLE_GC
     {
 #ifdef MICROPY_HW_SDRAM_SIZE
@@ -100,28 +114,54 @@ int main(int argc, char **argv) {
 
     mp_init();
     #if MICROPY_ENABLE_COMPILER
-    #if MICROPY_REPL_EVENT_DRIVEN
+    #if !MICROPY_REPL_EVENT_DRIVEN
+    for (;;)
+    {
+        int resp;
+        if(pyexec_mode_kind == PYEXEC_MODE_RAW_REPL)
+            resp = pyexec_raw_repl();
+        else
+            resp = pyexec_friendly_repl();
+
+        switch(resp)
+        {
+            case 0: continue;
+            case PYEXEC_FORCED_EXIT: //CTRL-D, do soft reset
+                break;
+            default:
+                return -1; //do hard reset
+        }
+        break;
+    }
+    #else
+    #error MICROPY_REPL_EVENT_DRIVEN is not tested!
     pyexec_event_repl_init();
-    for (;;) {
+    for (;;)
+    {
         int c = mp_hal_stdin_rx_chr();
         if (pyexec_event_repl_process_char(c)) {
             break;
         }
     }
-    #else
-    pyexec_friendly_repl();
     #endif
-    // do_str("print('hello world!', list(x+1 for x in range(10)), end='eol\\n')", MP_PARSE_SINGLE_INPUT);
-    // do_str("for i in range(10):\r\n  print(i)", MP_PARSE_FILE_INPUT);
     #else
-    pyexec_frozen_module("frozentest.py");
+    #error not enabling MICROPY_ENABLE_COMPILER is not tested!
     #endif
+
+
 
 #ifdef CSR_TIMER0_UPTIME_CYCLES_ADDR
     machine_timer_deinit_all();
 #endif
 
+    gc_sweep_all();
+    mp_hal_stdout_tx_strn("MPY: soft reboot\r\n", 18);
+    mp_hal_delay_us(10000); // allow UART to flush output
     mp_deinit();
+    #if MICROPY_REPL_EVENT_DRIVEN
+    pyexec_event_repl_init();
+    #endif
+
     return 0;
 }
 

--- a/ports/litex/modutime.c
+++ b/ports/litex/modutime.c
@@ -29,8 +29,12 @@
 #include "py/runtime.h"
 #include "extmod/utime_mphal.h"
 #include "lib/timeutils/timeutils.h"
-#include "litesdk_timer.h"
 
+void timer0_isr(void) {} //FIXME temp hack to use time functions
+#define LITETIMER_PERIOD_FROM_CYCLES64(c, mult) (uint32_t) (c*(uint64_t)mult/CONFIG_CLOCK_FREQUENCY)
+#ifndef CSR_TIMER0_UPTIME_LATCH_ADDR
+#warning CSR_TIMER0_UPTIME_LATCH_ADDR should be defined, use --timer-uptime at SoC generation
+#endif
 
 mp_uint_t mp_hal_ticks_us(void)
 {

--- a/ports/litex/modutime.c
+++ b/ports/litex/modutime.c
@@ -1,0 +1,144 @@
+/*
+ * This file is part of the MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Victor Suarez Rovere <suarezvictor@gmail.com>
+ * Copyright (c) 2019 Damien P. George
+ * Copyright (c) 2013, 2014 Damien P. George and 2017, 2018 Rami Ali
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "py/runtime.h"
+#include "extmod/utime_mphal.h"
+#include "lib/timeutils/timeutils.h"
+#include "litesdk_timer.h"
+
+
+mp_uint_t mp_hal_ticks_us(void)
+{
+    return LITETIMER_PERIOD_FROM_CYCLES64(litex_uptime(), 1000000);
+}
+
+mp_uint_t mp_hal_ticks_ms(void)
+{
+    return LITETIMER_PERIOD_FROM_CYCLES64(litex_uptime(), 1000);
+}
+
+uint64_t mp_hal_time_ns(void)
+{
+    return LITETIMER_PERIOD_FROM_CYCLES64(litex_uptime(), 1000000000ull);
+}
+
+mp_uint_t mp_hal_ticks_cpu(void)
+{
+    return litex_uptime();
+}
+
+void mp_hal_delay_ms(mp_uint_t ms)
+{
+    mp_uint_t start = mp_hal_ticks_ms();
+    while (mp_hal_ticks_ms() - start < ms);
+}
+
+// time()
+STATIC mp_obj_t time_time(void) {
+/*
+   static timeutils_struct_time_t t;
+#warning implement RTC
+    //rtc_get_datetime(&t);
+    return mp_obj_new_int_from_ull(timeutils_seconds_since_epoch(t.tm_year, t.tm_mon, t.tm_mday, t.tm_hour, t.tm_min, t.tm_sec));
+*/
+    mp_raise_NotImplementedError("time");
+}
+
+// localtime([secs])
+STATIC mp_obj_t time_localtime(size_t n_args, const mp_obj_t *args) {
+    timeutils_struct_time_t tm;
+    mp_int_t seconds;
+    if (n_args == 0 || args[0] == mp_const_none) {
+        // seconds = pyb_rtc_get_us_since_epoch() / 1000 / 1000;
+        seconds = mp_obj_get_int(args[0]);
+    } else {
+        seconds = mp_obj_get_int(args[0]);
+    }
+    timeutils_seconds_since_epoch_to_struct_time(seconds, &tm);
+    mp_obj_t tuple[8] = {
+        tuple[0] = mp_obj_new_int(tm.tm_year),
+        tuple[1] = mp_obj_new_int(tm.tm_mon),
+        tuple[2] = mp_obj_new_int(tm.tm_mday),
+        tuple[3] = mp_obj_new_int(tm.tm_hour),
+        tuple[4] = mp_obj_new_int(tm.tm_min),
+        tuple[5] = mp_obj_new_int(tm.tm_sec),
+        tuple[6] = mp_obj_new_int(tm.tm_wday),
+        tuple[7] = mp_obj_new_int(tm.tm_yday),
+    };
+    return mp_obj_new_tuple(8, tuple);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(time_localtime_obj, 0, 1, time_localtime);
+
+// mktime()
+STATIC mp_obj_t time_mktime(mp_obj_t tuple) {
+    size_t len;
+    mp_obj_t *elem;
+    mp_obj_get_array(tuple, &len, &elem);
+
+    // localtime generates a tuple of len 8. CPython uses 9, so we accept both.
+    if (len < 8 || len > 9) {
+        mp_raise_msg_varg(&mp_type_TypeError, MP_ERROR_TEXT("mktime needs a tuple of length 8 or 9 (%d given)"), len);
+    }
+
+    return mp_obj_new_int_from_uint(timeutils_mktime(mp_obj_get_int(elem[0]),
+        mp_obj_get_int(elem[1]), mp_obj_get_int(elem[2]), mp_obj_get_int(elem[3]),
+        mp_obj_get_int(elem[4]), mp_obj_get_int(elem[5])));
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(time_mktime_obj, time_mktime);
+
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(time_time_obj, time_time);
+
+STATIC const mp_rom_map_elem_t time_module_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_utime) },
+
+    { MP_ROM_QSTR(MP_QSTR_gmtime), MP_ROM_PTR(&time_localtime_obj) },
+    { MP_ROM_QSTR(MP_QSTR_localtime), MP_ROM_PTR(&time_localtime_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mktime), MP_ROM_PTR(&time_mktime_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_sleep), MP_ROM_PTR(&mp_utime_sleep_obj) },
+    { MP_ROM_QSTR(MP_QSTR_sleep_ms), MP_ROM_PTR(&mp_utime_sleep_ms_obj) },
+    { MP_ROM_QSTR(MP_QSTR_sleep_us), MP_ROM_PTR(&mp_utime_sleep_us_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_ticks_ms), MP_ROM_PTR(&mp_utime_ticks_ms_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ticks_us), MP_ROM_PTR(&mp_utime_ticks_us_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ticks_cpu), MP_ROM_PTR(&mp_utime_ticks_cpu_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_ticks_add), MP_ROM_PTR(&mp_utime_ticks_add_obj) },
+    { MP_ROM_QSTR(MP_QSTR_ticks_diff), MP_ROM_PTR(&mp_utime_ticks_diff_obj) },
+
+    { MP_ROM_QSTR(MP_QSTR_time), MP_ROM_PTR(&time_time_obj) },
+    { MP_ROM_QSTR(MP_QSTR_time_ns), MP_ROM_PTR(&mp_utime_time_ns_obj) },
+};
+
+STATIC MP_DEFINE_CONST_DICT(time_module_globals, time_module_globals_table);
+
+const mp_obj_module_t mp_module_utime = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&time_module_globals,
+};
+

--- a/ports/litex/mpconfigport.h
+++ b/ports/litex/mpconfigport.h
@@ -34,6 +34,13 @@ typedef long      mp_off_t;
 
 
 #include <generated/csr.h>
+#include <generated/mem.h>
+
+#ifdef MAIN_RAM_BASE
+#define MICROPY_HW_SDRAM_AVAIL (1)
+#define MICROPY_HW_SDRAM_BASE MAIN_RAM_BASE
+#define MICROPY_HW_SDRAM_SIZE MAIN_RAM_SIZE
+#endif
 
 // C-level pin HAL
 #define MP_HAL_PIN_FMT "%u"

--- a/ports/litex/mpconfigport.h
+++ b/ports/litex/mpconfigport.h
@@ -24,6 +24,7 @@
 #define MICROPY_PY_MACHINE_SPI_MSB          (1)
 #define MICROPY_PY_MACHINE_SPI_LSB          (0)
 #define MICROPY_PY_MACHINE_I2C              (1)
+#define MICROPY_PY_UTIME_MP_HAL             (1)
 
 // Type definitions for the specific machine
 
@@ -75,7 +76,15 @@ mp_hal_pin_obj_t pin_find(const void *pin_in);
 #define mp_hal_pin_od_low(p)
 #define mp_hal_pin_od_high(p)
 #define machine_pin_get_id(o) 0
+#endif
 
+#define TIMER0_POLLING //interrupt handing not enabled yet
+#ifdef CSR_TIMER0_UPTIME_LATCH_ADDR
+//TODO: use SDK
+static inline uint64_t litex_uptime() {  timer0_uptime_latch_write(1); return timer0_uptime_cycles_read(); }
+#else
+//calibrated for sleep_ms / sleep
+static inline uint64_t litex_uptime() { static uint64_t uptime = 0; return uptime+=250; }
 #endif
 
 #ifdef CSR_TIMER0_UPTIME_CYCLES_ADDR
@@ -93,9 +102,11 @@ static inline void mp_hal_delay_us_fast(mp_uint_t us) { us*=4; volatile static u
 
 extern const struct _mp_obj_module_t mp_module_machine;
 extern const struct _mp_obj_module_t mp_module_litex;
+extern const struct _mp_obj_module_t mp_module_utime;
 #define MICROPY_PORT_BUILTIN_MODULES \
     { MP_ROM_QSTR(MP_QSTR_umachine), MP_ROM_PTR(&mp_module_machine) }, \
     { MP_ROM_QSTR(MP_QSTR_litex),    MP_ROM_PTR(&mp_module_litex)   }, \
+    { MP_ROM_QSTR(MP_QSTR_utime), MP_ROM_PTR(&mp_module_utime) }, \
 
 // We need to provide a declaration/definition of alloca()
 #include <alloca.h>


### PR DESCRIPTION
Fix of pyboard functionality:

- standard time module (with basic timer emulation if not defined at SoC generation), plus an example/test
- garbage collector using the full SDRAM as heap, plus an example reporting allocation
- raw REPL, plus a basic example
